### PR TITLE
#160 & #203

### DIFF
--- a/app/Console/Commands/GameIntervalCommand.php
+++ b/app/Console/Commands/GameIntervalCommand.php
@@ -47,7 +47,7 @@ class GameIntervalCommand extends Command
         $gameController = new GameController();
         $lastUpdates = [];
 
-        while (1 < 2) {
+        while (true) {
             $game_ended = false;
             $this->log("Checking intervals");
 
@@ -93,7 +93,6 @@ class GameIntervalCommand extends Command
 
             sleep(5);
         }
-        return 0;
     }
 
     private function log($message)

--- a/resources/views/config/main.blade.php
+++ b/resources/views/config/main.blade.php
@@ -33,11 +33,11 @@
                             @csrf
                             @method('PUT')
                             <div class="form-item">
-                                <label class="form-label-0" for="duration">Tijdslimiet</label>
+                                <label class="form-label-0" for="duration">Spelduratie (min)</label>
                                 <input name="duration" class="input-numeric-0" id="duration" type="text">
                             </div>
                             <div class="form-item">
-                                <label class="form-label-0" for="interval">Interval locatieupdates</label>
+                                <label class="form-label-0" for="interval">Locatieupdate interval (sec)</label>
                                 <input name="interval" class="input-numeric-0" id="interval" type="text">
                             </div>
                             <div class="form-item">


### PR DESCRIPTION
`time_left` van een game wordt nu samen met elke game interval gecheckt en geüpdatet. Wanneer deze op of onder 0 komt te staan zou het spel automatisch eindigen.

Dit is nog geen geweldige oplossing aangezien de tijd overschreden kan worden tot 5 seconden nadat het spel eigenlijk al af is gelopen. Mochten mensen hiervoor een beter idee voor hebben sta ik daar natuurlijk ook voor open.

Elke 30 seconden wordt de timer van de time_left in de database nu ook geüpdatet.