### PR TITLE
Hotfix - Spel joinen dat al bezig is met 1 user erin veroorzaakt nu geen JSON error meer

### DIFF
--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -73,7 +73,12 @@ class GameController extends Controller
             }
         }
 
-        return $filtered_users;
+        $users = [];
+        foreach ($filtered_users as $user){
+            array_push($users, $user);
+        }
+
+        return $users;
     }
 
     public function getLoot(Game $game)


### PR DESCRIPTION
Dit voorkomt dat JSON in een vreemd formaat komt zoals dit:
```
{
  "0": {
    "id": 25,
    "username": "Boris",
    "location": "51.726984,5.5396849",
    "status": "playing",
    "triggered_alarm": null,
    "caught_at": null,
    "last_verified_at": "2021-06-17 13:46:20",
    "is_fake_agent": 1,
    "created_at": "2021-06-17T11:38:25.000000Z",
    "updated_at": "2021-06-17T11:46:20.000000Z",
    "role": "thief"
  },
  "3": {
    "id": 26,
    "username": "ann",
    "location": null,
    "status": "playing",
    "triggered_alarm": null,
    "caught_at": null,
    "last_verified_at": "2021-06-17 13:46:30",
    "is_fake_agent": null,
    "created_at": "2021-06-17T11:46:30.000000Z",
    "updated_at": "2021-06-17T11:46:30.000000Z",
    "role": "police"
  }
}
```
Er wordt namelijk een array verwacht (iets in blokhaken: `[{...}, {...}]`) en nu wordt het altijd als array gestuurd.